### PR TITLE
Add height and width to image

### DIFF
--- a/src/lib/Navbar.svelte
+++ b/src/lib/Navbar.svelte
@@ -26,7 +26,7 @@
 
 <header class:elevated>
 	<div class="container">
-		<nav>
+		<nav class="navbar">
 			<ul>
 				<li>
 					<a href="/" class="brand contrast" on:click={() => (menuExpanded = false)}>

--- a/src/lib/styles.scss
+++ b/src/lib/styles.scss
@@ -102,6 +102,10 @@
 }
 
 // Logo
+.navbar {
+	height: 90px;
+}
+
 .navbar img {
 	width: 47.5px;
 	min-height: 47.5px;

--- a/src/lib/styles.scss
+++ b/src/lib/styles.scss
@@ -100,3 +100,11 @@
 	margin-inline: auto;
 	padding-inline: var(--pico-spacing);
 }
+
+// Logo
+.navbar img {
+	width: 47.5px;
+	min-height: 47.5px;
+	border-radius: 50%;
+	object-fit: cover;
+}


### PR DESCRIPTION
Fixes #63 

<img width="745" alt="Screenshot 2024-06-09 at 7 31 41 PM" src="https://github.com/kendoclub-at-umich/website/assets/63531478/6bf6bfe4-2ebc-44de-8010-9222e92f9acc">


<img width="611" alt="Screenshot 2024-06-09 at 7 33 41 PM" src="https://github.com/kendoclub-at-umich/website/assets/63531478/28992bbd-c4ad-4781-8138-b5183fc18399">

Added height and width to the logo image explicitly so that the browser allocates the required space for the image before it is downloaded.