### PR TITLE
ci: 👷 allow dependabot to open 10 npm PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,4 @@ updates:
       day: sunday
     commit-message:
       prefix: 'build: ⬆️ '
+    open-pull-requests-limit: 10


### PR DESCRIPTION
this doubles the number of simultaneous PRs that dependabot can open