### PR TITLE
Add padding to support iOS safe area insets

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+		<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/lib/Navbar.svelte
+++ b/src/lib/Navbar.svelte
@@ -63,6 +63,10 @@
 </header>
 
 <style>
+	.container {
+		padding-top: env(safe-area-inset-top);
+	}
+
 	header {
 		--menu-transition-time: 0.1s;
 		position: sticky;

--- a/src/lib/styles.scss
+++ b/src/lib/styles.scss
@@ -98,5 +98,6 @@
 	width: 100%;
 	max-width: min(40rem, calc(75dvw + 120px));
 	margin-inline: auto;
-	padding-inline: var(--pico-spacing);
+	padding-left: max(var(--pico-spacing), env(safe-area-inset-left));
+	padding-right: max(var(--pico-spacing), env(safe-area-inset-right));
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -41,6 +41,7 @@
 	}
 	main {
 		padding-top: 32px;
+		padding-bottom: env(safe-area-inset-bottom);
 	}
 	footer > div {
 		display: flex;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -39,10 +39,12 @@
 		display: grid;
 		grid-template-rows: auto minmax(auto, 1fr) auto;
 	}
+
 	main {
 		padding-top: 32px;
 		padding-bottom: env(safe-area-inset-bottom);
 	}
+
 	footer > div {
 		display: flex;
 		justify-content: space-between;
@@ -50,6 +52,7 @@
 		font-weight: 200;
 		font-size: 0.75em;
 	}
+
 	@media (width<480px) {
 		footer > div {
 			flex-direction: column;


### PR DESCRIPTION
Fixes #129 

Make navbar stretch all the way across the screen with iOS notches instead of stopping inside of the safe area. Add padding to the bottom of the page based off safe area insets to make sure notches now won't cut off content and gesture bar doesn't overlap the copyright.