### PR TITLE
add protocol to iCal link and reword language

### DIFF
--- a/src/lib/FullCalendar.svelte
+++ b/src/lib/FullCalendar.svelte
@@ -101,7 +101,7 @@
 	let recentlyCopiedToClipboard = false;
 
 	async function copyIcalUrl() {
-		await navigator.clipboard.writeText(icalUrl);
+		await navigator.clipboard.writeText('https://' + icalUrl);
 		recentlyCopiedToClipboard = true;
 		setTimeout(() => {
 			recentlyCopiedToClipboard = false;
@@ -128,7 +128,7 @@
 			calendar.
 		</p>
 		<div role="group">
-			<input value={icalUrl} readonly />
+			<input value={'https://' + icalUrl} readonly />
 			{#if browser && 'clipboard' in navigator}
 				<button aria-label="Copy" on:click={copyIcalUrl}>
 					<SvgIcon label="" path={recentlyCopiedToClipboard ? mdiCheck : mdiContentCopy} />

--- a/src/lib/FullCalendar.svelte
+++ b/src/lib/FullCalendar.svelte
@@ -123,10 +123,7 @@
 >
 	<article>
 		<h2>Add to Your Calendar</h2>
-		<p>
-			Copy the iCal url into your calendar app to automatically add Kendo Club events to your
-			calendar.
-		</p>
+		<p>Subscribe to the Kendo Club calendar in your calendar app using this iCal link.</p>
 		<div role="group">
 			<input value={'https://' + icalUrl} readonly />
 			{#if browser && 'clipboard' in navigator}

--- a/src/lib/FullCalendar.svelte
+++ b/src/lib/FullCalendar.svelte
@@ -123,7 +123,9 @@
 >
 	<article>
 		<h2>Add to Your Calendar</h2>
-		<p>Subscribe to the Kendo Club calendar in your calendar app using this iCal link.</p>
+		<p>
+			Copy this iCal link into your calendar app to subscribe to the Kendo Club at Umich calendar.
+		</p>
 		<div role="group">
 			<input value={'https://' + icalUrl} readonly />
 			{#if browser && 'clipboard' in navigator}

--- a/src/lib/FullCalendar.svelte
+++ b/src/lib/FullCalendar.svelte
@@ -124,7 +124,7 @@
 	<article>
 		<h2>Add to Your Calendar</h2>
 		<p>
-			Copy this iCal link into your calendar app to subscribe to the Kendo Club at Umich calendar.
+			Copy this iCal url into your calendar app to subscribe to the Kendo Club at Umich calendar.
 		</p>
 		<div role="group">
 			<input value={'https://' + icalUrl} readonly />


### PR DESCRIPTION
Fixes #185 
- Add protocol to iCal link b/c we mistakenly left it out
- Reword language in "Add to Other Calendar button" description to "subscribe". Makes it easier to find the place to paste the iCal link into other calendar apps.