### PR TITLE
Fix and improve styling of "Add To Other Calendar" copy button 

### DIFF
--- a/src/lib/FullCalendar.svelte
+++ b/src/lib/FullCalendar.svelte
@@ -104,29 +104,31 @@
 
 <!-- Reason: Dialog can be closed with esc key, so it's already able to be interacted with -->
 <!-- svelte-ignore a11y-click-events-have-key-events  a11y-no-noninteractive-element-interactions-->
-<dialog
-	bind:this={addToOtherCalendarDialog}
-	on:click={(event) => {
-		if (event.target == addToOtherCalendarDialog) {
-			addToOtherCalendarDialog.close();
-		}
-	}}
->
-	<article>
-		<h2>Add to Your Calendar</h2>
-		<p>
-			Copy this iCal url into your calendar app to subscribe to the Kendo Club at Umich calendar.
-		</p>
-		<div role="group">
-			<input value={'https://' + icalUrl} readonly />
-			{#if browser && 'clipboard' in navigator}
-				<button aria-label="Copy" on:click={copyIcalUrl}>
-					<SvgIcon label="" path={recentlyCopiedToClipboard ? mdiCheck : mdiContentCopy} />
-				</button>
-			{/if}
-		</div>
-	</article>
-</dialog>
+<div class="pico">
+	<dialog
+		bind:this={addToOtherCalendarDialog}
+		on:click={(event) => {
+			if (event.target == addToOtherCalendarDialog) {
+				addToOtherCalendarDialog.close();
+			}
+		}}
+	>
+		<article>
+			<h2>Add to Your Calendar</h2>
+			<p>
+				Copy this iCal url into your calendar app to subscribe to the Kendo Club at Umich calendar.
+			</p>
+			<div role="group">
+				<input value={'https://' + icalUrl} readonly />
+				{#if browser && 'clipboard' in navigator}
+					<button aria-label="Copy" on:click={copyIcalUrl}>
+						<SvgIcon label="" path={recentlyCopiedToClipboard ? mdiCheck : mdiContentCopy} />
+					</button>
+				{/if}
+			</div>
+		</article>
+	</dialog>
+</div>
 
 <style>
 	:global(main:has(#full-calendar)) {

--- a/src/lib/FullCalendar.svelte
+++ b/src/lib/FullCalendar.svelte
@@ -144,5 +144,6 @@
 	button {
 		display: grid;
 		place-items: center;
+		padding: var(--pico-form-element-spacing-vertical);
 	}
 </style>

--- a/src/lib/FullCalendar.svelte
+++ b/src/lib/FullCalendar.svelte
@@ -104,31 +104,29 @@
 
 <!-- Reason: Dialog can be closed with esc key, so it's already able to be interacted with -->
 <!-- svelte-ignore a11y-click-events-have-key-events  a11y-no-noninteractive-element-interactions-->
-<div class="pico">
-	<dialog
-		bind:this={addToOtherCalendarDialog}
-		on:click={(event) => {
-			if (event.target == addToOtherCalendarDialog) {
-				addToOtherCalendarDialog.close();
-			}
-		}}
-	>
-		<article>
-			<h2>Add to Your Calendar</h2>
-			<p>
-				Copy this iCal url into your calendar app to subscribe to the Kendo Club at Umich calendar.
-			</p>
-			<div role="group">
-				<input value={'https://' + icalUrl} readonly />
-				{#if browser && 'clipboard' in navigator}
-					<button aria-label="Copy" on:click={copyIcalUrl}>
-						<SvgIcon label="" path={recentlyCopiedToClipboard ? mdiCheck : mdiContentCopy} />
-					</button>
-				{/if}
-			</div>
-		</article>
-	</dialog>
-</div>
+<dialog
+	bind:this={addToOtherCalendarDialog}
+	on:click={(event) => {
+		if (event.target == addToOtherCalendarDialog) {
+			addToOtherCalendarDialog.close();
+		}
+	}}
+>
+	<article>
+		<h2>Add to Your Calendar</h2>
+		<p>
+			Copy this iCal url into your calendar app to subscribe to the Kendo Club at Umich calendar.
+		</p>
+		<div role="group">
+			<input value={'https://' + icalUrl} readonly />
+			{#if browser && 'clipboard' in navigator}
+				<button aria-label="Copy" on:click={copyIcalUrl}>
+					<SvgIcon label="" path={recentlyCopiedToClipboard ? mdiCheck : mdiContentCopy} />
+				</button>
+			{/if}
+		</div>
+	</article>
+</dialog>
 
 <style>
 	:global(main:has(#full-calendar)) {

--- a/src/lib/FullCalendar.svelte
+++ b/src/lib/FullCalendar.svelte
@@ -140,4 +140,9 @@
 		font-size: min(18px, 0.75em);
 		max-width: max(640px, calc((4 / 3) * (100lvh - 225px)));
 	}
+
+	button {
+		display: grid;
+		place-items: center;
+	}
 </style>

--- a/src/lib/FullCalendar.svelte
+++ b/src/lib/FullCalendar.svelte
@@ -120,7 +120,7 @@
 		<div role="group">
 			<input value={'https://' + icalUrl} readonly />
 			{#if browser && 'clipboard' in navigator}
-				<button aria-label="Copy" on:click={copyIcalUrl}>
+				<button class="copy-button" aria-label="Copy" on:click={copyIcalUrl}>
 					<SvgIcon label="" path={recentlyCopiedToClipboard ? mdiCheck : mdiContentCopy} />
 				</button>
 			{/if}
@@ -139,7 +139,7 @@
 		max-width: max(640px, calc((4 / 3) * (100lvh - 225px)));
 	}
 
-	button {
+	.copy-button {
 		display: grid;
 		place-items: center;
 		padding: var(--pico-form-element-spacing-vertical);


### PR DESCRIPTION
Closes #176 
* Fix styles after transitioning to PicoCSS conditional mode (forgot to enable styling on the "Add to Calendar" buttons' dialogs
* Center icons in the buttons
* Make the buttons narrower