### PR TITLE
invert pico class to default to applying pico styles

### DIFF
--- a/src/lib/EventInfo.svelte
+++ b/src/lib/EventInfo.svelte
@@ -41,7 +41,7 @@
 	$: extendedProps = event.extendedProps as ExtendedProps;
 </script>
 
-<div class="event-detail-grid pico">
+<div class="event-detail-grid">
 	<h3 class="header">{event.title}</h3>
 
 	<SvgIcon label="Time" path={mdiClockOutline} />

--- a/src/lib/FullCalendar.svelte
+++ b/src/lib/FullCalendar.svelte
@@ -100,7 +100,7 @@
 	}
 </script>
 
-<div id="full-calendar" bind:this={calendarElement} />
+<div id="full-calendar" class="no-pico" bind:this={calendarElement} />
 
 <!-- Reason: Dialog can be closed with esc key, so it's already able to be interacted with -->
 <!-- svelte-ignore a11y-click-events-have-key-events  a11y-no-noninteractive-element-interactions-->

--- a/src/lib/Navbar.svelte
+++ b/src/lib/Navbar.svelte
@@ -25,7 +25,7 @@
 
 <svelte:document on:scroll={checkIfElevated} />
 
-<header class="pico" class:elevated>
+<header class:elevated>
 	<div class="container">
 		<nav>
 			<ul>

--- a/src/lib/styles.scss
+++ b/src/lib/styles.scss
@@ -1,5 +1,5 @@
 @use '@picocss/pico/scss/pico' with (
-	$parent-selector: ':where(.pico)',
+	$parent-selector: ':where(:not(.no-pico, .no-pico *)) >',
 	$theme-color: 'amber',
 	$modules: (
 		// Theme

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -36,11 +36,11 @@
 
 <Navbar {logoUrl} siteName="Kendo Club at Umich" {pages} />
 
-<main class="container" class:pico={$page.route.id != '/calendar'}>
+<main class="container">
 	<slot />
 </main>
 
-<footer class="pico">
+<footer>
 	<div class="container">
 		<span>&copy; {copyright}</span>
 		<span>


### PR DESCRIPTION
Needing to put `pico` everywhere makes things a pain so this PR makes it so that we can just put `no-pico` on the parent of things that should not have pico styles applied. This may add some performance issues because this is in all Pico selectors but hopefully, it's not too much of an issue because Pico is pretty lightweight and browsers are well-optimized.