### PR TITLE
refactor: ♻️ remove event url directly in source

### DIFF
--- a/src/lib/FullCalendar.svelte
+++ b/src/lib/FullCalendar.svelte
@@ -51,13 +51,13 @@
 			},
 			googleCalendarApiKey,
 			events: { googleCalendarId },
-			eventDidMount: ({ el, event, view }) => {
-				let component: EventInfo | undefined;
-				if (view.type == 'listMonth') {
-					el.querySelector('a')?.removeAttribute('href');
-				} else {
-					el.removeAttribute('href');
+			eventSourceSuccess: (events) => {
+				for (const event of events) {
+					delete event.url;
 				}
+			},
+			eventDidMount: ({ el, event }) => {
+				let component: EventInfo | undefined;
 				el.setAttribute('tabindex', '0');
 
 				tippy(el, {


### PR DESCRIPTION
By default, Full Calendar makes events links that open google calendar when clicked. We are currently disabling this by removing the href from the events after Full Calendar has already created the HTML element. In this PR I change it so that we remove the URL from the event before Full Calendar makes the HTML elements so that it never makes the events link to google calendar in the first place.