### PR TITLE
chore: 🔧 allow dependabot PRs any day of the week.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,17 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    schedule:
+      interval: daily
+      time: '9:00'
+      timezone: America/Detroit
     commit-message:
       prefix: 'ci: 👷 '
   - package-ecosystem: npm
     directory: /
+    schedule:
+      interval: daily
+      time: '9:00'
+      timezone: America/Detroit
     commit-message:
       prefix: 'build: ⬆️ '

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,3 @@ updates:
     directory: /
     commit-message:
       prefix: 'build: ⬆️ '
-    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
-      time: '9:00'
+      time: '06:00'
       timezone: America/Detroit
     commit-message:
       prefix: 'ci: 👷 '
@@ -12,7 +12,7 @@ updates:
     directory: /
     schedule:
       interval: daily
-      time: '9:00'
+      time: '06:00'
       timezone: America/Detroit
     commit-message:
       prefix: 'build: ⬆️ '

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,10 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
-    schedule:
-      interval: weekly
-      day: sunday
     commit-message:
       prefix: 'ci: 👷 '
   - package-ecosystem: npm
     directory: /
-    schedule:
-      interval: weekly
-      day: sunday
     commit-message:
       prefix: 'build: ⬆️ '
     open-pull-requests-limit: 10


### PR DESCRIPTION
Because we aren't really doing sprints anymore.