### PR TITLE
Improve transliterations of opening and closing remarks

### DIFF
--- a/src/routes/resources/lineup-closing-commands/+page.svelte
+++ b/src/routes/resources/lineup-closing-commands/+page.svelte
@@ -11,7 +11,7 @@
 
 <hgroup>
 	<h1>Kendo Line-Up Commands End of Practice</h1>
-	<p>phonetically written for non-Japanese speaker and also with Japanese</p>
+	<p>With english transliterations and Japanese</p>
 </hgroup>
 
 <p>
@@ -19,7 +19,7 @@
 		After the final Waza or Keiko has been ended, Sensei will call out final Rei.<br />
 		Once the Sankyo and Rei is completed, call out...<br />
 	</span>
-	“Sigh Rets !!” This is the call to return to line up again.<br />
+	“Say Rets !!” This is the call to return to line up again.<br />
 	整列（せいれつ）<br />
 	<span class="secondary">
 		(This needs to be said loud enough for everyone to hear) As the lead in the line-up, remember
@@ -55,7 +55,7 @@
 </p>
 
 <p>
-	“Mok Sooooooooooo !!” Meditate.<br />
+	“Moak Sooooooooooo !!” Meditate.<br />
 	黙想（もくそう）<br />
 	<span class="secondary">
 		This command should be followed by a brief pause of silence so everyone can silently reflect on
@@ -65,12 +65,12 @@
 </p>
 
 <p>
-	“Mok So Yah May !!” Stop meditating.<br />
+	“Moak So Yah May !!” Stop meditating.<br />
 	黙想やめ（もくそうやめ）<br />
 </p>
 
 <p>
-	“Sho Men Ni !!” Face the Shomen direction.<br />
+	“Show-Men Ni !!” Face the Shomen direction.<br />
 	正面に（しょうめんに）<br />
 	<span class="secondary">Pause long enough for everyone to face toward the clock.</span><br />
 	“Ray !!” Bow from Seiza position.<br />

--- a/src/routes/resources/lineup-opening-commands/+page.svelte
+++ b/src/routes/resources/lineup-opening-commands/+page.svelte
@@ -11,14 +11,14 @@
 
 <hgroup>
 	<h1>Kendo Line-Up Commands Beginning Practice</h1>
-	<p>phonetically written for non-Japanese speaker and also with Japanese</p>
+	<p>With english transliterations and Japanese</p>
 </hgroup>
 
 <p>
 	<span class="secondary">
 		After the final Rei from the stretching or foot work drills, call out...
 	</span><br />
-	“Sigh Rets !!” This is the call to line up.<br />
+	“Say Rets !!” This is the call to line up.<br />
 	整列（せいれつ）<br />
 	<span class="secondary">(this needs to be said loud enough for everyone to hear)</span>
 </p>
@@ -47,7 +47,7 @@
 </p>
 
 <p>
-	“Mok Sooooooooooo !!” Meditate<br />
+	“Moak Sooooooooooo !!” Meditate<br />
 	黙想（もくそう<br />
 	<span class="secondary">
 		This command should be followed by a brief pause of silence so everyone can silently reflect.
@@ -55,12 +55,12 @@
 </p>
 
 <p>
-	“Mok-So Yah-May !!” Stop meditating.<br />
+	“Moak-So Yah-May !!” Stop meditating.<br />
 	黙想やめ（もくそうやめ<br />
 </p>
 
 <p>
-	“Sho-Men Ni !!” Face the Shomen direction.<br />
+	“Show-Men Ni !!” Face the Shomen direction.<br />
 	正面に（しょうめんに）<br />
 	<span class="secondary">Pause long enough for everyone to face toward the clock.</span><br />
 	“Ray !!” Bow from Seiza position.<br />


### PR DESCRIPTION
- call them transliterations instead of phonetic writing because it's more accurate
- make reader more likely to succeed at pronouncing words correctly by using spellings that make the correct pronunciation far more likely (ex "say" instead of "sigh", "moak" instead of "mok", which might be pronounced as "mock")