### PR TITLE
Zalhabash/html resources opening and closing remarks edits

### DIFF
--- a/src/routes/resources/lineup-closing-commands/+page.svelte
+++ b/src/routes/resources/lineup-closing-commands/+page.svelte
@@ -19,7 +19,7 @@
 		After the final Waza or Keiko has been ended, Sensei will call out final Rei.<br />
 		Once the Sankyo and Rei is completed, call out...<br />
 	</span>
-	“Say Rets !!” This is the call to return to line up again.<br />
+	“Say-Rets !!” This is the call to return to line up again.<br />
 	整列（せいれつ）<br />
 	<span class="secondary">
 		(This needs to be said loud enough for everyone to hear) As the lead in the line-up, remember
@@ -34,14 +34,14 @@
 		/>
 		After the last of the Sensei/teachers moves to sitting position, call out…<br />
 	</span>
-	“Chyak Sa !!” or “Say-Za !!” Move to Seiza position quickly, DO NOT remove your gear.<br />
+	“Chyak-Sa !!” or “Say-Za !!” Move to Seiza position quickly, DO NOT remove your gear.<br />
 	着座（ちゃくざ）又は正座（せいざ）<br />
 </p>
 
 <p>
 	<span class="secondary">Once all of the Sensei have removed their Men, then you can call…</span
 	><br />
-	Men-O-toe ray !! Remove your equipment<br />
+	Men O toe-ray !! Remove your equipment<br />
 	面をとれ（めんをとれ）<br />
 </p>
 
@@ -50,12 +50,12 @@
 		>Visually confirm that the line is straight and everyone has their gear in a straight line, then
 		call out…</span
 	><br />
-	“Key Oat-Skay !!” Draw yourself to sharp attention in the Seiza position<br />
+	“Key Oat Skay !!” Draw yourself to sharp attention in the Seiza position<br />
 	気をつけ（きをつけ）<br />
 </p>
 
 <p>
-	“Moak Sooooooooooo !!” Meditate.<br />
+	“Moak-Sooooooooooo !!” Meditate.<br />
 	黙想（もくそう）<br />
 	<span class="secondary">
 		This command should be followed by a brief pause of silence so everyone can silently reflect on
@@ -65,7 +65,7 @@
 </p>
 
 <p>
-	“Moak So Yah May !!” Stop meditating.<br />
+	“Moak-So Yah-May !!” Stop meditating.<br />
 	黙想やめ（もくそうやめ）<br />
 </p>
 
@@ -78,7 +78,7 @@
 </p>
 
 <p>
-	“Sensei knee !!” or “Sensei gata knee !!”<br />
+	“Sen-sei knee !!” or “Sen-sei ga-ta knee !!”<br />
 	先生に（せんせいに）又は先生方に（せんせいがたに） Face the Sensei.<br />
 	<span class="secondary">
 		If there is only one Sensei, then the first or if there are two or more use the second. Pause
@@ -93,7 +93,7 @@
 </p>
 
 <p>
-	“Ota Gai Knee !!” Face the direction of your partners.<br />
+	“Ota-Gai Knee !!” Face the direction of your partners.<br />
 	お互いに（おたがいに）<br />
 	<span class="secondary">
 		This will always be the same direction as Sensei.<br />
@@ -108,7 +108,7 @@
 		Pause so the Sensei can give closing remarks, if there is not enough time left then you will
 		announce where to meet for after practice announcements.<br />
 	</span>
-	“Key Oat-Skay, Ray !!” Final Rei from the Seiza position before clearing out the room.<br />
+	“Key Oat Skay, Ray !!” Final Rei from the Seiza position before clearing out the room.<br />
 	気をつけ、礼（きをつけ、れい）<br />
 </p>
 

--- a/src/routes/resources/lineup-opening-commands/+page.svelte
+++ b/src/routes/resources/lineup-opening-commands/+page.svelte
@@ -18,7 +18,7 @@
 	<span class="secondary">
 		After the final Rei from the stretching or foot work drills, call out...
 	</span><br />
-	“Say Rets !!” This is the call to line up.<br />
+	“Say-Rets !!” This is the call to line up.<br />
 	整列（せいれつ）<br />
 	<span class="secondary">(this needs to be said loud enough for everyone to hear)</span>
 </p>
@@ -29,7 +29,7 @@
 		Wait for all of the people to line up standing along-side your position. After the last of the
 		Sensei/teachers moves to sitting position, call out…
 	</span><br />
-	“Chyak Sa !!” or “Say-Za !!” Move to Seiza position and quickly set up your equipment.<br />
+	“Chyak-Sa !!” or “Say-Za !!” Move to Seiza position and quickly set up your equipment.<br />
 	着座（ちゃくざ）又は正座（せいざ<br />
 	<span class="secondary">
 		Everyone will be looking to you for where to place their equipment, so be as quick as you can
@@ -47,7 +47,7 @@
 </p>
 
 <p>
-	“Moak Sooooooooooo !!” Meditate<br />
+	“Moak-Sooooooooooo !!” Meditate<br />
 	黙想（もくそう<br />
 	<span class="secondary">
 		This command should be followed by a brief pause of silence so everyone can silently reflect.
@@ -68,7 +68,7 @@
 </p>
 
 <p>
-	“Sensei Knee !!” or “Sensei Gata Knee !!” Face the Sensei.<br />
+	“Sen-sei Knee !!” or “Sen-sei Ga-ta Knee !!” Face the Sensei.<br />
 	先生に（せんせいに）又は先生方に（せんせいがたに）<br />
 	<span class="secondary">
 		If there is only one Sensei, then the first or if there are two or more use the second. Pause
@@ -80,7 +80,7 @@
 </p>
 
 <p>
-	“Ota Gai Knee !!” Face the direction of your partners.<br />
+	“Ota-Gai Knee !!” Face the direction of your partners.<br />
 	お互いに（おたがいに）<br />
 	<span class="secondary">
 		This will always be the same direction as Sensei.<br />


### PR DESCRIPTION
Forgot to include this in the last pr.

Made hyphens consistent in the english transliteration. Now hyphens separate syllables and spaces between the english represent separate japanese words. Ex. "Sen-sei knee"