### PR TITLE
Make corrections suggested by Archie to dictionary resources

### DIFF
--- a/src/routes/resources/kendo-japanese-pronunciations-and-definitions/+page.svelte
+++ b/src/routes/resources/kendo-japanese-pronunciations-and-definitions/+page.svelte
@@ -197,7 +197,7 @@
 
 <h3>At the start and end of practice:</h3>
 <dl>
-	<dt>Retsu: 列 【れつ】</dt>
+	<dt>Seiretsu: 整列 【せいれつ】</dt>
 	<dd>line, or to form a line</dd>
 
 	<dt>Kiwotsuke (pronounced Kyotsuke): 気を付け 【きをつけ】</dt>
@@ -401,10 +401,10 @@
 	<dt>Shiai: 試合 【しあい】</dt>
 	<dd>competition</dd>
 
-	<dt>Waza: 業 【わざ】</dt>
+	<dt>Waza: 技 【わざ】</dt>
 	<dd>technique</dd>
 
-	<dt>Kihon waza: 基本業【きほんわざ】</dt>
+	<dt>Kihon waza: 基本技【きほんわざ】</dt>
 	<dd>basic techniques</dd>
 
 	<dt>Sashi-men: 差し面【さしめん】</dt>
@@ -496,7 +496,7 @@
 		a long time to develop or extend it.
 	</dd>
 
-	<dt>Issoku-ittou: 一束一刀 【いっそくいっとう】</dt>
+	<dt>Issoku-ittou: 一足一刀 【いっそくいっとう】</dt>
 	<dd>“One step, one sword”</dd>
 
 	<dt>To-ma : 遠間 【とおま】</dt>


### PR DESCRIPTION
> A couple of corrections:
> (1) we say Seiretsu(整列) instead of Retsu (列) for line-up;
> (2) the character for waza should be 技 instead of 業;
> (3) the characters for issoku-itto should be 一足一刀 instead of 一束一刀.
https://github.com/kendoclub-at-umich/website/pull/392#pullrequestreview-2512852251