### PR TITLE
add prepare npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
 		"format": "prettier --write .",
-		"dependencies": "node inject-theme-colors.js"
+		"dependencies": "node inject-theme-colors.js",
+		"prepare": "svelte-kit sync"
 	},
 	"devDependencies": {
 		"@eslint/js": "10.0.0",


### PR DESCRIPTION
Fixes an error where the $lib alias was unknown because the .svelte-kit folder containing the tsconfig.json was missing