### PR TITLE
chore: :wrench: turn off eslint no navigation without resolve for simplicity

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,6 +30,7 @@ export default ts.config(
 			eqeqeq: ['error', 'smart'],
 			'svelte/block-lang': ['error', { script: 'ts' }],
 			'svelte/spaced-html-comment': 'error',
+			'svelte/no-navigation-without-resolve': 'off',
 			'@typescript-eslint/no-confusing-void-expression': ['error', { ignoreArrowShorthand: true }],
 			'@typescript-eslint/consistent-indexed-object-style': 'off',
 			'@typescript-eslint/consistent-type-definitions': 'off',


### PR DESCRIPTION
In order to keep the project maintainable for potential beginners, forgo using `resolve(route)` and continue to use URLs in href. Project is currently simple enough for this to probably be fine.