### PR TITLE
ci: 👷 do not use CPU slowdown on already slow CPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,4 @@ jobs:
           temporaryPublicStorage: true
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          LHCI_SETTINGS__THROTTLING__CPU_SLOWDOWN_MULTIPLIER: 1


### PR DESCRIPTION
By default lighthouse assumes that you are running it on a powerfull desktop computer so it intentionally slows down the CPU inside the browser to get more acurate results representing the avrage user. However GitHub actions has a relitivly weak CPU that is already over worked so this PR tells lighthouse in GitHub actions to not slow down the CPU.

more documentation: https://github.com/GoogleChrome/lighthouse/blob/main/docs/throttling.md#cpu-throttling