### PR TITLE
fix: :wrench: use correct sitemap urls during production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-PUBLIC_BASE_URL=${URL:-http://localhost:4173}
+PUBLIC_BASE_URL=http://localhost:4173

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,6 @@
 [build]
-command = "npm run build"
+command = "PUBLIC_BASE_URL=$DEPLOY_PRIME_URL npm run build"
 publish = "build"
+
+[context.production]
+command = "PUBLIC_BASE_URL=$URL npm run build"


### PR DESCRIPTION
Netlify's env variable DEPLOY_PRIME_URL is formatted like a deploy URL without using our custom domain during prod. We have to switch to using the env var URL in order to correct that.

Fixes #754 