### PR TITLE
remove @types/eslint__js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
 				"@sveltejs/kit": "^2.49.3",
 				"@sveltejs/vite-plugin-svelte": "^6.2.4",
 				"@types/chroma-js": "^3.1.2",
-				"@types/eslint__js": "^9.14.0",
 				"@types/node": "^24.10.8",
 				"@types/web-app-manifest": "^1.0.9",
 				"chroma-js": "^3.2.0",
@@ -2035,17 +2034,6 @@
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
 			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
 			"dev": true
-		},
-		"node_modules/@types/eslint__js": {
-			"version": "9.14.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint__js/-/eslint__js-9.14.0.tgz",
-			"integrity": "sha512-s0jepCjOJWB/GKcuba4jISaVpBudw3ClXJ3fUK4tugChUMQsp6kSwuA8Dcx6wFd/JsJqcY8n4rEpa5RTHs5ypA==",
-			"deprecated": "This is a stub types definition. @eslint/js provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@eslint/js": "*"
-			}
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
@@ -6124,15 +6112,6 @@
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
 			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
 			"dev": true
-		},
-		"@types/eslint__js": {
-			"version": "9.14.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint__js/-/eslint__js-9.14.0.tgz",
-			"integrity": "sha512-s0jepCjOJWB/GKcuba4jISaVpBudw3ClXJ3fUK4tugChUMQsp6kSwuA8Dcx6wFd/JsJqcY8n4rEpa5RTHs5ypA==",
-			"dev": true,
-			"requires": {
-				"@eslint/js": "*"
-			}
 		},
 		"@types/estree": {
 			"version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
 		"@sveltejs/kit": "^2.49.3",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@types/chroma-js": "^3.1.2",
-		"@types/eslint__js": "^9.14.0",
 		"@types/node": "^24.10.8",
 		"@types/web-app-manifest": "^1.0.9",
 		"chroma-js": "^3.2.0",


### PR DESCRIPTION
npm gave a nice deprecation warning. Apparently @eslint/js provides its own type definitions, which is very nice.