### PR TITLE
fix: 🐛 construct date with universally supported format

### DIFF
--- a/src/routes/resources/what-is-rei/+page.svelte
+++ b/src/routes/resources/what-is-rei/+page.svelte
@@ -9,7 +9,7 @@
 		extraInfo={{
 			type: 'article',
 			author: 'Ken Wakabayashi',
-			publishedTime: new Date('February 2006')
+			publishedTime: new Date('2006-02')
 		}}
 	/>
 </svelte:head>


### PR DESCRIPTION
fixes #898. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format